### PR TITLE
Fix article document createdAt error

### DIFF
--- a/src/blog/schemas/article.schema.ts
+++ b/src/blog/schemas/article.schema.ts
@@ -89,6 +89,13 @@ export class Article {
 
   @Prop({ default: 0 })
   trendingScore: number; // For trending algorithm
+
+  // Timestamps (automatically added by Mongoose when timestamps: true)
+  @Prop({ type: Date })
+  createdAt: Date;
+
+  @Prop({ type: Date })
+  updatedAt: Date;
 }
 
 export const ArticleSchema = SchemaFactory.createForClass(Article);


### PR DESCRIPTION
Add `createdAt` and `updatedAt` properties to `Article` schema to resolve TypeScript error due to missing Mongoose timestamps.

Mongoose's `timestamps: true` automatically adds `createdAt` and `updatedAt` fields to documents, but these were not explicitly defined in the TypeScript `Article` class, leading to a `TS2339` error when accessing them.

---
<a href="https://cursor.com/background-agent?bcId=bc-788a8bdb-6a9e-482a-bffe-a61bcafd95db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-788a8bdb-6a9e-482a-bffe-a61bcafd95db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

